### PR TITLE
enforced integer division for indexing

### DIFF
--- a/scripts/iu-filter-quality-minoche
+++ b/scripts/iu-filter-quality-minoche
@@ -80,7 +80,7 @@ def IsHighQuality(sequence, quality, p):
         return (False, trim_to, 'FAILED_REASON_N')
 
     # C33
-    half_length = len(quality) / 2
+    half_length = len(quality) // 2
     if len([True for _q in quality[0:half_length] if _q > 30]) < 0.66 * half_length:
         # Exclude Sequence
         return (False, trim_to, 'FAILED_REASON_C33')


### PR DESCRIPTION
Python 3 introduced "true" division and can produce float values from two integers unless directly type cast or if the floor division operator is used.  I propose using the latter when computing the half_length variable as it is required to be of type int when used to slice quality in C33 check.