### PR TITLE
Options to report prefix and trim suffix sequences

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,25 +10,26 @@ Feel free to cite [this article](http://journals.plos.org/plosone/article?id=10.
 
 # Contents
 
+- [Contents](#contents)
 - [Installing](#installing)
+  - [Standard installation](#standard-installation)
+  - [Slightly better setup (with virtualenv)](#slightly-better-setup-with-virtualenv)
+    - [Pro setup](#pro-setup)
 - [Demultiplexing](#demultiplexing)
 - [Config File Format](#config-file-format)
-    - [[general] section](#general-section)
-    - [[files] section](#files-section)
-    - [[prefixes] section](#prefixes-section)
+  - [[general] section](#general-section)
+  - [[files] section](#files-section)
+  - [[prefixes] section](#prefixes-section)
 - [Merging Partially Overlapping Illumina Pairs](#merging-partially-overlapping-illumina-pairs)
-    - [Example STATS output](#example-stats-output)
-    - [Recovering high-quality reads from merged reads file](#recovering-high-quality-reads-from-merged-reads-file)
+  - [Example STATS output](#example-stats-output)
 - [Merging Completely Overlapping Illumina Pairs](#merging-completely-overlapping-illumina-pairs)
 - [Quality Filtering](#quality-filtering)
-    - ["Complete Overlap" analysis for V6](#complete-overlap-analysis-for-v6)
-        - [Example STATS output](#example-stats-output)
-    - [Minoche et al.](#minoche-et-al)
-        - [Example STATS output](#example-stats-output)
-        - [Example PNG files](#example-png-files)
-    - [Bokulich et al.](#bokulich-et-al)
-        - [Example STATS output:](#example-stats-output)
-        - [Example PNG files](#example-png-files)
+  - [Minoche et al.](#minoche-et-al)
+    - [Example STATS output](#example-stats-output-1)
+    - [Example PNG files](#example-png-files)
+  - [Bokulich et al.](#bokulich-et-al)
+    - [Example STATS output:](#example-stats-output)
+    - [Example PNG files](#example-png-files-1)
 - [Questions?](#questions)
 
 
@@ -139,7 +140,7 @@ Before describing the purpose of each section, here is a useful note: in most ca
 
 This is a mandatory section that contains `project_name`, `researcher_email`, `input_directory` and `output_directory` directives.
 
-Two critical declerations in `[general]` section are `input_directory` and `output_directory`:
+Two critical declarations in `[general]` section are `input_directory` and `output_directory`:
 
 * `input_directory`: Full path to the directory where FASTQ files reside.
 * `output_directory`: Full path to the directory where the output of the operation you will perform on this config to be stored. Since when it is Illumina we are dealing with huge files, the codebase is pretty conservative to protect users from making simple mistakes which may result in huge losses. So, if you don't create the `output_directory`, you will get an error (it will not be automatically generated). If there is already a file in the `output_directory` with the same name with one of the outputs, you will get an error (it will not be overwritten). `project_name` will be used as a prefix for the naming convention of output files, so it would be wise to choose something descriptive and UNIX-compatible.
@@ -150,7 +151,7 @@ Two critical declerations in `[general]` section are `input_directory` and `outp
 
 ## [prefixes] section
 
-`prefixes` section is optional. If you have barcodes and primers in your reads, and you want them to be trimmed, you can use [regular expression](http://en.wikipedia.org/wiki/Regular_expressions)s to specify them. If prefixes are defined, results would contain only pairs that matched them.
+`prefixes` section is optional. If you have primers, barcodes or unique molecular identifiers (UMIs) in your reads, and you want them to be trimmed, you can use [regular expression](http://en.wikipedia.org/wiki/Regular_expressions)s to specify them. A UMI, being a random sequence, would be represented by a series of dots (...... would represent a UMI of length 6). If prefixes are defined, results would contain only pairs that matched them.
 
 
 # Merging Partially Overlapping Illumina Pairs
@@ -274,6 +275,8 @@ Please use `iu-merge-pairs` the same way explained in the [Merging Partially Ove
 You can be extremely stringent with this approach by allowing 0 mismatches at the overlapped region:
 
     (...) --marker-gene-stringent --retain-only-overlap --max-num-mismatches 0
+
+Completely overlapping pairs can contain parts of the adapters at the ends of the sequence, as read 1 can continue into the read 2 adapter, and read 2 can continue into the read 1 adapter. You can trim these "suffix" sequences with the `--trim-suffix` flag.
 
 An example complete overlap analysis is demonstrated in the [examples](https://github.com/meren/illumina-utils/tree/master/examples) directory of the codebase.
 

--- a/scripts/iu-merge-pairs
+++ b/scripts/iu-merge-pairs
@@ -174,6 +174,9 @@ class Merger:
         self.enforce_Q30_check = False
         self.retain_only_overlap = False
         self.marker_gene_stringent = False
+        self.trim_suffix = False
+        self.report_r1_prefix = False
+        self.report_r2_prefix = False
         self.project_name = 'Unknown_project'
 
         if self.config.pair_1_prefix:
@@ -278,7 +281,7 @@ class Merger:
                     (alt_beginning, alt_overlap, alt_end), alt_number_of_mismatches, alt_recovery_dict =\
                                                              self.merge_two_sequences_fast(complete_overlap = True)
 
-                    if self.retain_only_overlap:
+                    if self.retain_only_overlap or self.trim_suffix:
                         alt_merged_sequence = alt_overlap
                     else:
                         alt_merged_sequence = alt_beginning + alt_overlap + alt_end
@@ -310,7 +313,6 @@ class Merger:
                         self.stats.num_Q30_fails_in_read_2 += 1
                     elif not r1_passed_Q30 and not r2_passed_Q30:
                         self.stats.num_Q30_fails_in_both += 1
-
 
                 # generate the header line
                 header_line = '%s|o:%d|m/o:%f|MR:%s|Q30:%s|CO:%d|mismatches:%d' % \
@@ -383,6 +385,12 @@ class Merger:
                 # record the info for successfuly merged pair in recovery dict
                 self.stats.process_recovery_dict(recovery_dict)
 
+                if self.report_r1_prefix and self.pair_1_prefix_compiled:
+                    self.read1prefixes.write_id(header_line)
+                    self.read1prefixes.write_seq(pattern_1.group(0))
+                if self.report_r2_prefix and self.pair_2_prefix_compiled:
+                    self.read2prefixes.write_id(header_line)
+                    self.read2prefixes.write_seq(pattern_2.group(0))
 
                 # FIXME: this is ridiculous. visualization of the Q-score curves associated
                 # part needs to be moved somewhere else.
@@ -490,6 +498,11 @@ class Merger:
             self.Q30fails = P('_FAILED_Q30')
         else:
             self.Q30fails = None
+            
+        if self.report_r1_prefix:
+            self.read1prefixes = P('_MERGED_R1_PREFIX')
+        if self.report_r2_prefix:
+            self.read2prefixes = P('_MERGED_R2_PREFIX')
 
 
     def close_output_files(self):
@@ -498,6 +511,10 @@ class Merger:
         self.withNs.close()
         if self.enforce_Q30_check:
             self.Q30fails.close()
+        if self.report_r1_prefix:
+            self.read1prefixes.close()
+        if self.report_r2_prefix:
+            self.read2prefixes.close()
 
 
     def get_read_id_with_better_base_qual(self, base_index_in_read_1, base_index_in_reversed_read_2):
@@ -741,6 +758,30 @@ if __name__ == '__main__':
                                         help = 'Finds the best merge going beyond expected "partial\
                                                 overlap" case for amplicons. Please read the description\
                                                 at url https://github.com/meren/illumina-utils/issues/1 for details.')
+    parser.add_argument('--trim-suffix', action = 'store_true', default = False,
+                                        help = 'Some datasets contain both partially and completely overlapping reads.\
+                                                "--marker-gene-stringent" would be used in that case.\
+                                                Completely overlapping reads can contain\
+                                                unwanted adapter sequence at the ends of the reads\
+                                                (read 1 adapter at the end of read 2\
+                                                and read 2 adapter at the end of read 1).\
+                                                This flag trims these adapter suffixes from merged reads,\
+                                                but unlike setting "--retain-only-overlap",\
+                                                it does not discard non-overlapping parts of the insert\
+                                                from partially-overlapping reads.')
+    parser.add_argument('--report-r1-prefix', action = 'store_true', default = False,
+                                        help = 'If there is a prefix to read 1 specified in the config file,\
+                                                these sequences will be reported for merged reads\
+                                                when this flag is set.\
+                                                This can be useful if the prefix sequence has variable bases,\
+                                                such as in a unique molecular identifier (UMI).')
+    parser.add_argument('--report-r2-prefix', action = 'store_true', default = False,
+                                        help = 'If there is a prefix to read 2 specified in the config file,\
+                                                these sequences will be reported for merged reads\
+                                                when this flag is set.\
+                                                This can be useful if the prefix sequence has variable bases,\
+                                                such as in a unique molecular identifier (UMI).')
+
 
     args = parser.parse_args()
 
@@ -766,5 +807,8 @@ if __name__ == '__main__':
     merger.ignore_deflines = args.ignore_deflines
     merger.retain_only_overlap = args.retain_only_overlap
     merger.marker_gene_stringent = args.marker_gene_stringent
+    merger.trim_suffix = args.trim_suffix
+    merger.report_r1_prefix = args.report_r1_prefix
+    merger.report_r2_prefix = args.report_r2_prefix
 
     sys.exit(merger.run())


### PR DESCRIPTION
This is a pretty simple change which does **not** include the faster merging of reads with no mismatches in the overlap, another feature I've been working on. The changes are largely explained by the help messages for the three new command line arguments and required surprisingly few modifications to the code.

The `--trim-suffix` option is critical for merging reads with a distribution of insert sizes resulting in a mixture of completely and partially overlapping inserts, as `--marker-gene-stringent` truncates merged partially overlapping reads.

The `--report-r1-prefix` and `--report-r2-prefix` report "prefix" sequences from merged reads. An example prefix sequence can be a unique molecular identifier of six random nucleotides located at the beginning of read 1 (immediately before the insert), which in the `config` file would be specified by the regex string, `......`.

I tested these changes with datasets spanning a range of sizes and a combination of options.